### PR TITLE
Update LiveDataExt.kt

### DIFF
--- a/kaal-infrastructure/src/main/kotlin/cz/eman/kaal/infrastructure/coroutines/channels/LiveDataExt.kt
+++ b/kaal-infrastructure/src/main/kotlin/cz/eman/kaal/infrastructure/coroutines/channels/LiveDataExt.kt
@@ -16,9 +16,9 @@ import kotlinx.coroutines.channels.Channel
 fun <T> LiveData<T>.observeChannel(lifecycleOwner: LifecycleOwner? = null): Channel<T?> {
     val liveDataChannel = LiveDataChannel(this)
 
-    lifecycleOwner?.let {
-        observe(it, liveDataChannel)
-        it.lifecycle.addObserver(liveDataChannel)
+    lifecycleOwner?.apply {
+        observe(this, liveDataChannel)
+        this.lifecycle.addObserver(liveDataChannel)
     } ?: run {
         observeForever(liveDataChannel)
     }


### PR DESCRIPTION
Combination of a `?.let {}` with `?: run` can lead to unexpected behaviour. Since `let` returns its result, if the last expression of `let` resolves to null, then `run` is also executed. So you end up with both parts executed. `Apply` on the other hand returns `this` value, so no matter what let resolves to, run is only executed if the initial value is null