### PR TITLE
✨ #5: Add Layout id to Base Fragment and Activity

### DIFF
--- a/kaal-presentation/src/main/kotlin/cz/eman/kaal/presentation/activity/BaseActivity.kt
+++ b/kaal-presentation/src/main/kotlin/cz/eman/kaal/presentation/activity/BaseActivity.kt
@@ -1,5 +1,6 @@
 package cz.eman.kaal.presentation.activity
 
+import androidx.annotation.LayoutRes
 import androidx.appcompat.app.AppCompatActivity
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -11,9 +12,13 @@ import kotlinx.coroutines.cancel
  * @see[AppCompatActivity]
  * @since 0.1.0
  */
-abstract class BaseActivity : AppCompatActivity(), CoroutineScope {
+abstract class BaseActivity : AppCompatActivity, CoroutineScope {
 
     override val coroutineContext = Dispatchers.Main + SupervisorJob()
+
+    constructor(): super()
+
+    constructor(@LayoutRes contentLayoutId: Int): super(contentLayoutId)
 
     override fun onDestroy() {
         super.onDestroy()

--- a/kaal-presentation/src/main/kotlin/cz/eman/kaal/presentation/fragment/BaseFragment.kt
+++ b/kaal-presentation/src/main/kotlin/cz/eman/kaal/presentation/fragment/BaseFragment.kt
@@ -1,5 +1,6 @@
 package cz.eman.kaal.presentation.fragment
 
+import androidx.annotation.LayoutRes
 import androidx.fragment.app.Fragment
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -11,9 +12,13 @@ import kotlinx.coroutines.cancel
  * @see[Fragment]
  * @since 0.1.0
  */
-abstract class BaseFragment : Fragment(), CoroutineScope {
+abstract class BaseFragment : Fragment, CoroutineScope {
 
     override val coroutineContext = Dispatchers.Main + SupervisorJob()
+
+    constructor(): super()
+
+    constructor(@LayoutRes contentLayoutId: Int): super(contentLayoutId)
 
     override fun onDestroy() {
         super.onDestroy()

--- a/sample/src/main/java/cz/eman/kaal/MainActivity.kt
+++ b/sample/src/main/java/cz/eman/kaal/MainActivity.kt
@@ -4,10 +4,4 @@ import android.os.Bundle
 import cz.eman.kaal.presentation.activity.BaseActivity
 import cz.eman.kaal.sample.R
 
-class MainActivity : BaseActivity() {
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        setContentView(R.layout.activity_main)
-    }
-}
+class MainActivity : BaseActivity(R.layout.activity_main)

--- a/sample/src/main/res/values/strings.xml
+++ b/sample/src/main/res/values/strings.xml
@@ -1,3 +1,3 @@
 <resources>
-    <string name="app_name">kotlin-emandroid-extensions</string>
+    <string name="app_name">Kaal Lib Example</string>
 </resources>


### PR DESCRIPTION
resolve #5 https://github.com/eManPrague/kaal/issues/5 Added possibility to define a layout by using a constructor instead of calling standard setContent in Activity or standard layout inflater in the Fragment
