### PR TITLE
🎨 Simplify structure of base Android classes

### DIFF
--- a/kaal-presentation/src/main/kotlin/cz/eman/kaal/presentation/activity/BaseActivity.kt
+++ b/kaal-presentation/src/main/kotlin/cz/eman/kaal/presentation/activity/BaseActivity.kt
@@ -12,13 +12,11 @@ import kotlinx.coroutines.cancel
  * @see[AppCompatActivity]
  * @since 0.1.0
  */
-abstract class BaseActivity : AppCompatActivity, CoroutineScope {
+abstract class BaseActivity @JvmOverloads constructor(
+    @LayoutRes contentLayoutId: Int = 0
+) : AppCompatActivity(contentLayoutId), CoroutineScope {
 
     override val coroutineContext = Dispatchers.Main + SupervisorJob()
-
-    constructor(): super()
-
-    constructor(@LayoutRes contentLayoutId: Int): super(contentLayoutId)
 
     override fun onDestroy() {
         super.onDestroy()

--- a/kaal-presentation/src/main/kotlin/cz/eman/kaal/presentation/fragment/BaseFragment.kt
+++ b/kaal-presentation/src/main/kotlin/cz/eman/kaal/presentation/fragment/BaseFragment.kt
@@ -12,13 +12,11 @@ import kotlinx.coroutines.cancel
  * @see[Fragment]
  * @since 0.1.0
  */
-abstract class BaseFragment : Fragment, CoroutineScope {
+abstract class BaseFragment @JvmOverloads constructor(
+    @LayoutRes contentLayoutId: Int = 0
+) : Fragment(contentLayoutId), CoroutineScope {
 
     override val coroutineContext = Dispatchers.Main + SupervisorJob()
-
-    constructor(): super()
-
-    constructor(@LayoutRes contentLayoutId: Int): super(contentLayoutId)
 
     override fun onDestroy() {
         super.onDestroy()


### PR DESCRIPTION
The explicitly created constructors are replaced one constructor with
default value of parameter. The constructor has @JvmOverloads
annotation to maintain Java interoperability.