### PR TITLE
💥 Remove Coroutine scope from classes with lifecycle

### DIFF
--- a/kaal-presentation/src/main/kotlin/cz/eman/kaal/presentation/activity/BaseActivity.kt
+++ b/kaal-presentation/src/main/kotlin/cz/eman/kaal/presentation/activity/BaseActivity.kt
@@ -2,10 +2,6 @@ package cz.eman.kaal.presentation.activity
 
 import androidx.annotation.LayoutRes
 import androidx.appcompat.app.AppCompatActivity
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 
 /**
  * @author vsouhrada (vaclav.souhrada@eman.cz)
@@ -14,14 +10,6 @@ import kotlinx.coroutines.cancel
  */
 abstract class BaseActivity @JvmOverloads constructor(
     @LayoutRes contentLayoutId: Int = 0
-) : AppCompatActivity(contentLayoutId), CoroutineScope {
-
-    override val coroutineContext = Dispatchers.Main + SupervisorJob()
-
-    override fun onDestroy() {
-        super.onDestroy()
-        coroutineContext.cancel()
-    }
-}
+) : AppCompatActivity(contentLayoutId)
 
 //fun Activity.findParentNavController() = Navigation.findNavController(this, R.id.navHostFragment)

--- a/kaal-presentation/src/main/kotlin/cz/eman/kaal/presentation/dialog/BaseDialogFragment.kt
+++ b/kaal-presentation/src/main/kotlin/cz/eman/kaal/presentation/dialog/BaseDialogFragment.kt
@@ -1,22 +1,10 @@
 package cz.eman.kaal.presentation.dialog
 
 import androidx.fragment.app.DialogFragment
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 
 /**
  * @author vsouhrada (vaclav.souhrada@eman.cz)
  * @see[DialogFragment]
  * @since 0.1.0
  */
-abstract class BaseDialogFragment : DialogFragment(), CoroutineScope {
-
-    override val coroutineContext = Dispatchers.Main + SupervisorJob()
-
-    override fun onDestroy() {
-        super.onDestroy()
-        coroutineContext.cancel()
-    }
-}
+abstract class BaseDialogFragment : DialogFragment()

--- a/kaal-presentation/src/main/kotlin/cz/eman/kaal/presentation/fragment/BaseFragment.kt
+++ b/kaal-presentation/src/main/kotlin/cz/eman/kaal/presentation/fragment/BaseFragment.kt
@@ -2,10 +2,6 @@ package cz.eman.kaal.presentation.fragment
 
 import androidx.annotation.LayoutRes
 import androidx.fragment.app.Fragment
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancel
 
 /**
  * @author vsouhrada (vaclav.souhrada@eman.cz)
@@ -14,14 +10,6 @@ import kotlinx.coroutines.cancel
  */
 abstract class BaseFragment @JvmOverloads constructor(
     @LayoutRes contentLayoutId: Int = 0
-) : Fragment(contentLayoutId), CoroutineScope {
-
-    override val coroutineContext = Dispatchers.Main + SupervisorJob()
-
-    override fun onDestroy() {
-        super.onDestroy()
-        coroutineContext.cancel()
-    }
-}
+) : Fragment(contentLayoutId)
 
 //fun Fragment.findParentNavController() = Navigation.findNavController(activity!!, R.id.navHostFragment)


### PR DESCRIPTION
In lifecycle-runtime-ktx Jetpack library of version 2.2.0-alpha01
has been released LifecycleScope. The LifecycleScope is defined for
each Lifecycle object and this scope lifetime traces Android lifecycle.

See https://developer.android.com/topic/libraries/architecture/coroutines#lifecyclescope