### PR TITLE
✨ Add suspendable map call

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Change Log
 
 ## 0.7.0 (TBD)
 
+### Added
+- `map` functions call parameter could be now a suspend. This allow to us call suspendable functions inside of mappers.
+
 ### Changed
 - `Api Break:` [#13](https://github.com/eManPrague/kaal/issues/13) - `Base` prefix has been replaced by a new `Kaal` prefix (`BaseFragment` -> `KaalFragment`, ...)
 - Kotlin Coroutines updated to [v1.3.5](https://github.com/Kotlin/kotlinx.coroutines/releases/tag/1.3.5)

--- a/kaal-infrastructure/src/main/kotlin/cz/eman/kaal/infrastructure/common/Common.kt
+++ b/kaal-infrastructure/src/main/kotlin/cz/eman/kaal/infrastructure/common/Common.kt
@@ -15,7 +15,7 @@ import retrofit2.Response
 suspend fun <Dto, T> callResult(
     responseCall: suspend () -> Response<Dto>,
     errorMessage: () -> String?,
-    map: (Dto) -> T
+    map: suspend (Dto) -> T
 ): Result<T> {
     try {
         val response = responseCall()


### PR DESCRIPTION
Changed that map functions call parameter could is now a suspendable. This allow to us call suspendable functions inside of mappers.