### PR TITLE
✨ ViewModel.launch extension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,9 @@ Change Log
 
 ## 0.8.0 (TBD)
 
+### Added
+- ViewModel extension enabling to launch Coroutine on viewModelScope without writing the viewModelScope part.
+
 ### Changed
 - Gradle updated to [v6.4.1](https://docs.gradle.org/6.4.1/release-notes.html)
 - Gradle build tools updated to v4.0.0

--- a/kaal-presentation/src/main/kotlin/cz/eman/kaal/presentation/viewmodel/ViewModelExtensions.kt
+++ b/kaal-presentation/src/main/kotlin/cz/eman/kaal/presentation/viewmodel/ViewModelExtensions.kt
@@ -1,0 +1,21 @@
+package cz.eman.kaal.presentation.viewmodel
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.CoroutineStart
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlin.coroutines.CoroutineContext
+import kotlin.coroutines.EmptyCoroutineContext
+
+/**
+ * Extension enabling to launch Coroutine on viewModelScope without writing the viewModelScope
+ * part. For more information check the original function [CoroutineScope.launch].
+ * @since 0.8.0
+ */
+fun ViewModel.launch(
+    context: CoroutineContext = EmptyCoroutineContext,
+    start: CoroutineStart = CoroutineStart.DEFAULT,
+    block: suspend CoroutineScope.() -> Unit
+): Job = this.viewModelScope.launch(context, start, block)


### PR DESCRIPTION
### Added
- ViewModel extension enabling to launch Coroutine on viewModelScope without writing the viewModelScope part.