### PR TITLE
Added caller and Result Extensions

### DIFF
--- a/kaal-domain/src/main/kotlin/cz/eman/kaal/domain/result/HttpStatusErrorCode.kt
+++ b/kaal-domain/src/main/kotlin/cz/eman/kaal/domain/result/HttpStatusErrorCode.kt
@@ -5,6 +5,8 @@ package cz.eman.kaal.domain.result
  * The codes are defined according to [Internet standard](https://www.ietf.org/assignments/http-status-codes/http-status-codes.xml).
  *
  * The types of error:
+ * - 3xx: Redirects - Can be considered as error = not success, some libraries (ex.: Retrofit2 does not conciser 300 as
+ *   success)
  * - 4xx: Client Error - The request contains bad syntax or cannot be fulfilled
  * - 5xx: Server Error - The server failed to fulfill an apparently valid request
  *
@@ -13,6 +15,17 @@ package cz.eman.kaal.domain.result
  */
 @Suppress("unused")
 enum class HttpStatusErrorCode(override val value: Int) : ErrorCode {
+
+    // 3xx Redirects (can be considered as error = not success)
+    MULTIPLE_CHOICES(300),
+    MOVED_PERMANENTLY(301),
+    FOUND(302),
+    SEE_OTHER(303),
+    NOT_MODIFIED(304),
+    USE_PROXY(305),
+    SWITCH_PROXY(306),
+    TEMPORARY_REDIRECT(307),
+
     // 4xx Client Error
     BAD_REQUEST(400),
     UNAUTHORIZED(401),

--- a/kaal-domain/src/main/kotlin/cz/eman/kaal/domain/result/HttpStatusErrorCode.kt
+++ b/kaal-domain/src/main/kotlin/cz/eman/kaal/domain/result/HttpStatusErrorCode.kt
@@ -54,18 +54,18 @@ enum class HttpStatusErrorCode(override val value: Int) : ErrorCode {
     INSUFFICIENT_STORAGE(507),
     LOOP_DETECTED(508),
     NOT_EXTENDED(510),
-    NETWORK_AUTHENTICATION_REQUIRED(511);
+    NETWORK_AUTHENTICATION_REQUIRED(511),
+
+    // Custom errors
+    UNKNOWN_HOST(1000),
+    SOCKET_TIMEOUT(1001);
 
     companion object {
         /**
          * Returns the enum constant of this type with the specified [value].
          *
          * @param value Integer representation of the error status
-         *
-         * @throws IllegalArgumentException If this enum type has no constant with the specified [value].
          */
-        @Throws(IllegalArgumentException::class)
-        fun valueOf(value: Int) = values().find { it.value == value }
-            ?: throw IllegalArgumentException("Unknown HTTP error status code: $value")
+        fun valueOf(value: Int) = values().find { it.value == value } ?: ErrorCode.UNDEFINED
     }
 }

--- a/kaal-domain/src/main/kotlin/cz/eman/kaal/domain/result/HttpStatusErrorCode.kt
+++ b/kaal-domain/src/main/kotlin/cz/eman/kaal/domain/result/HttpStatusErrorCode.kt
@@ -2,7 +2,8 @@ package cz.eman.kaal.domain.result
 
 /**
  * The enum defines standard HTTP status codes which represent client or server error.
- * The codes are defined according to [Internet standard](https://www.ietf.org/assignments/http-status-codes/http-status-codes.xml).
+ * The codes are defined according to [Internet standard](https://www.ietf.org/assignments/http-status-codes/http-status-codes.xml),
+ * [Rest Api tutorial](https://www.restapitutorial.com/httpstatuscodes.html).
  *
  * The types of error:
  * - 3xx: Redirects - Can be considered as error = not success, some libraries (ex.: Retrofit2 does not conciser 300 as
@@ -45,6 +46,8 @@ enum class HttpStatusErrorCode(override val value: Int) : ErrorCode {
     UNSUPPORTED_MEDIA_TYPE(415),
     RANGE_NOT_SATISFIABLE(416),
     EXPECTATION_FAILED(417),
+    NOT_A_TEAPOT(418),
+    ENHANCE_YOUR_CALM(420),
     MISDIRECTED_REQUEST(421),
     UNPROCESSABLE_ENTITY(422),
     LOCKED(423),
@@ -54,7 +57,11 @@ enum class HttpStatusErrorCode(override val value: Int) : ErrorCode {
     PRECONDITION_REQUIRED(428),
     TOO_MANY_REQUESTS(429),
     REQUEST_HEADER_FIELDS_TOO_LARGE(431),
+    NO_RESPONSE(444),
+    RETRY_WITH(449),
+    BLOCKED_BY_PARENAL_CONTROL(450),
     UNAVAILABLE_FOR_LEGAL_REASONS(451),
+    CLIENT_CLOSED_REQUEST(499),
 
     // 5xx Server Error
     INTERNAL_SERVER_ERROR(500),
@@ -66,8 +73,11 @@ enum class HttpStatusErrorCode(override val value: Int) : ErrorCode {
     VARIANT_ALSO_NEGOTIATES(506),
     INSUFFICIENT_STORAGE(507),
     LOOP_DETECTED(508),
+    BANDWIDTH_LIMIT_EXCEEDED(509),
     NOT_EXTENDED(510),
     NETWORK_AUTHENTICATION_REQUIRED(511),
+    NETWORK_READ_TIMEOUT_ERROR(598),
+    NETWORK_CONNECTED_TIMEOUT_ERROR(599),
 
     // Custom errors
     UNKNOWN_HOST(1000),

--- a/kaal-domain/src/main/kotlin/cz/eman/kaal/domain/result/ResultExtensions.kt
+++ b/kaal-domain/src/main/kotlin/cz/eman/kaal/domain/result/ResultExtensions.kt
@@ -1,0 +1,242 @@
+@file:Suppress("UNCHECKED_CAST")
+
+package cz.eman.kaal.domain.result
+
+/**
+ * Extensions for Result class.
+ *
+ * @author: eMan a.s.
+ * @since 0.9.0
+ */
+
+/**
+ * Maps success part of the Result using a [mapAction]. Keeps error as it is. This should be used only to handle / map
+ * the result object to another. It should not be used to chain other functions. For that there is a [chain] function.
+ *
+ * @param mapAction map function for body of [Result.Success] branch
+ * @return [Result] with [S]
+ * @since 0.9.0
+ */
+inline fun <T, S> Result<T>.map(mapAction: (T) -> S): Result<S> {
+    return when (this) {
+        is Result.Success -> Result.Success(mapAction(this.data))
+        is Result.Error -> Result.error(this.error, null)
+    }
+}
+
+/**
+ * Maps success part of the Result using a [mapAction]. Keeps error as it is. This should be used only to handle / map
+ * the result object to another. It should not be used to chain other functions. For that there is a [chain] function.
+ *
+ * @param mapAction map function for [Result.Success] branch
+ * @return [Result] with [S]
+ * @since 0.9.0
+ */
+inline fun <T, S> Result<T>.mapResult(mapAction: (T) -> Result<S>): Result<S> {
+    return when (this) {
+        is Result.Success -> mapAction(this.data)
+        is Result.Error -> Result.error(this.error, null)
+    }
+}
+
+/**
+ * Chains an action on the success of the current Result. Use to call other functions on success of this this [Result].
+ * Does not call the the [chainAction] on error.
+ *
+ * @param chainAction chain function for [Result.Success]
+ * @return [Result] with [S]
+ * @since 0.9.0
+ */
+inline infix fun <T, S> Result<T>.chain(chainAction: (T) -> Result<S>): Result<S> {
+    return when (this) {
+        is Result.Success -> chainAction(this.data)
+        is Result.Error -> Result.error(this.error, null)
+    }
+}
+
+/**
+ * Retypes [Result.Error] to a [Result.Error] with new error code. Keeps the message and throwable the same.
+ *
+ * @param newErrorCode to be retyped to
+ * @return [Result] with [S]
+ * @since 0.9.0
+ */
+fun <T, S> Result.Error<T>.retypeErrorCode(newErrorCode: ErrorCode? = null): Result<S> =
+    Result.error(
+        ErrorResult(
+            code = newErrorCode ?: this.error.code,
+            message = this.error.message,
+            throwable = this.error.throwable
+        ), null
+    )
+
+/**
+ * Runs a [block] function after the result finishes. Returns this to allow chaining of additional functions.
+ *
+ * @param block of code to run
+ * @return [Result] with [T] which the same as call [Result]
+ * @since 0.9.0
+ */
+fun <T> Result<T>.onFinished(block: (Result<T>) -> Unit): Result<T> {
+    block(this)
+    return this
+}
+
+/**
+ * Runs a [block] function only when current [Result] is successful. Returns this to allow chaining of additional
+ * functions.
+ *
+ * @param block of code to run on success
+ * @return [Result] with [T] which the same as call [Result]
+ * @since 0.9.0
+ */
+inline fun <T> Result<T>.onSuccess(block: (T) -> Unit): Result<T> {
+    if (this is Result.Success<T>) {
+        block(this.data)
+    }
+    return this
+}
+
+/**
+ * Runs a [block] function only when current [Result] fails with an error. Returns this to allow chaining of additional
+ * functions.
+ *
+ * @param block of code to run on error
+ * @return [Result] which the same as call [Result]
+ * @since 0.9.0
+ */
+inline fun Result<*>.onError(block: (ErrorResult) -> Unit): Result<*> {
+    if (this is Result.Error<*>) {
+        block(this.error)
+    }
+    return this
+}
+
+/**
+ * Converts object [T] into [Result.Success] containing [T] only when calling object is not null. Else it builds
+ * [ErrorResult] and fills [Result.error] with it.
+ *
+ * @param error used to build [ErrorResult] when predicate is false
+ * @return [Result] with [T] calling object
+ * @see toSuccessIfPredicate
+ */
+inline fun <T : Any> T?.toSuccessIfNotNull(error: () -> ErrorResult): Result<T> =
+    toSuccessIfPredicate(
+        error = error,
+        predicate = { this != null }
+    )
+
+/**
+ * Converts object [T] into [Result.Success] containing [T] only when [predicate] returns true. Else it builds
+ * [ErrorResult] and fills [Result.error] with it.
+ *
+ * @param predicate condition to check before wrapping the object in [Result.Success]
+ * @param error used to build [ErrorResult] when predicate is false
+ * @return [Result] with [T] calling object
+ */
+inline fun <T : Any> T?.toSuccessIfPredicate(
+    predicate: (T?) -> Boolean,
+    error: () -> ErrorResult
+): Result<T> {
+    return if (this != null && predicate(this)) {
+        this.toSuccess()
+    } else {
+        Result.error(error())
+    }
+}
+
+/**
+ * Maps any object to [Result.Success] containing this object.
+ *
+ * @return [Result.Success] with [T] calling object
+ */
+fun <T : Any> T.toSuccess(): Result<T> {
+    return Result.success(this)
+}
+
+/**
+ * Combines two successful results ([T1], [T2]) into one single result [R]. If any of the two result is a [Result.Error]
+ * then it returns it to handle the error state.
+ *
+ * @param other second [Result] to combine with the first one
+ * @param transform function combining two results
+ * @return [Result] with [R] data
+ * @see 0.9.0
+ */
+inline fun <T1 : Any, T2 : Any, R : Any> Result<T1>.combine(
+    other: Result<T2>,
+    transform: (T1, T2) -> R
+): Result<R> {
+    return when {
+        this is Result.Error<*> -> this as Result.Error<R>
+        other is Result.Error<*> -> other as Result.Error<R>
+        else -> Result.Success(
+            transform(
+                (this as Result.Success).data,
+                (other as Result.Success).data
+            )
+        )
+    }
+}
+
+/**
+ * Combines three successful results ([T1], [T2], [T3]) into one single result [R]. If any of the three result is a
+ * [Result.Error] then it returns it to handle the error state.
+ *
+ * @param two second [Result] to combine with the other ones
+ * @param three third [Result] to combine with the other ones
+ * @param transform function combining three results
+ * @return [Result] with [R] data
+ * @see 0.9.0
+ */
+inline fun <T1 : Any, T2 : Any, T3 : Any, R : Any> Result<T1>.combine(
+    two: Result<T2>,
+    three: Result<T3>,
+    transform: (T1, T2, T3) -> R
+): Result<R> {
+    return when {
+        this is Result.Error<*> -> this as Result.Error<R>
+        two is Result.Error<*> -> two as Result.Error<R>
+        three is Result.Error<*> -> three as Result.Error<R>
+        else -> Result.Success(
+            transform(
+                (this as Result.Success).data,
+                (two as Result.Success).data,
+                (three as Result.Success).data
+            )
+        )
+    }
+}
+
+/**
+ * Combines four successful results ([T1], [T2], [T3], [T4]) into one single result [R]. If any of the four result is a
+ * [Result.Error] then it returns it to handle the error state.
+ *
+ * @param two second [Result] to combine with the other ones
+ * @param three third [Result] to combine with the other ones
+ * @param four fourth [Result] to combine with the other ones
+ * @param transform function combining four results
+ * @return [Result] with [R] data
+ * @see 0.9.0
+ */
+inline fun <T1 : Any?, T2 : Any, T3 : Any, T4 : Any, R : Any> Result<T1>.combine(
+    two: Result<T2>,
+    three: Result<T3>,
+    four: Result<T4>,
+    transform: (T1, T2, T3, T4) -> R
+): Result<R> {
+    return when {
+        this is Result.Error<*> -> this as Result.Error<R>
+        two is Result.Error<*> -> two as Result.Error<R>
+        three is Result.Error<*> -> three as Result.Error<R>
+        four is Result.Error<*> -> four as Result.Error<R>
+        else -> Result.Success(
+            transform(
+                (this as Result.Success).data,
+                (two as Result.Success).data,
+                (three as Result.Success).data,
+                (four as Result.Success).data
+            )
+        )
+    }
+}

--- a/kaal-domain/src/main/kotlin/cz/eman/kaal/domain/result/ResultExtensions.kt
+++ b/kaal-domain/src/main/kotlin/cz/eman/kaal/domain/result/ResultExtensions.kt
@@ -1,4 +1,4 @@
-@file:Suppress("UNCHECKED_CAST")
+@file:Suppress("unused")
 
 package cz.eman.kaal.domain.result
 
@@ -119,6 +119,7 @@ inline fun Result<*>.onError(block: (ErrorResult) -> Unit): Result<*> {
  * @param error used to build [ErrorResult] when predicate is false
  * @return [Result] with [T] calling object
  * @see toSuccessIfPredicate
+ * @since 0.9.0
  */
 inline fun <T : Any> T?.toSuccessIfNotNull(error: () -> ErrorResult): Result<T> =
     toSuccessIfPredicate(
@@ -133,6 +134,7 @@ inline fun <T : Any> T?.toSuccessIfNotNull(error: () -> ErrorResult): Result<T> 
  * @param predicate condition to check before wrapping the object in [Result.Success]
  * @param error used to build [ErrorResult] when predicate is false
  * @return [Result] with [T] calling object
+ * @since 0.9.0
  */
 inline fun <T : Any> T?.toSuccessIfPredicate(
     predicate: (T?) -> Boolean,
@@ -149,6 +151,7 @@ inline fun <T : Any> T?.toSuccessIfPredicate(
  * Maps any object to [Result.Success] containing this object.
  *
  * @return [Result.Success] with [T] calling object
+ * @since 0.9.0
  */
 fun <T : Any> T.toSuccess(): Result<T> {
     return Result.success(this)
@@ -168,8 +171,8 @@ inline fun <T1 : Any, T2 : Any, R : Any> Result<T1>.combine(
     transform: (T1, T2) -> R
 ): Result<R> {
     return when {
-        this is Result.Error<*> -> this as Result.Error<R>
-        other is Result.Error<*> -> other as Result.Error<R>
+        this is Result.Error<*> -> this.retypeErrorCode()
+        other is Result.Error<*> -> other.retypeErrorCode()
         else -> Result.Success(
             transform(
                 (this as Result.Success).data,
@@ -195,9 +198,9 @@ inline fun <T1 : Any, T2 : Any, T3 : Any, R : Any> Result<T1>.combine(
     transform: (T1, T2, T3) -> R
 ): Result<R> {
     return when {
-        this is Result.Error<*> -> this as Result.Error<R>
-        two is Result.Error<*> -> two as Result.Error<R>
-        three is Result.Error<*> -> three as Result.Error<R>
+        this is Result.Error<*> -> this.retypeErrorCode()
+        two is Result.Error<*> -> two.retypeErrorCode()
+        three is Result.Error<*> -> three.retypeErrorCode()
         else -> Result.Success(
             transform(
                 (this as Result.Success).data,
@@ -226,10 +229,10 @@ inline fun <T1 : Any?, T2 : Any, T3 : Any, T4 : Any, R : Any> Result<T1>.combine
     transform: (T1, T2, T3, T4) -> R
 ): Result<R> {
     return when {
-        this is Result.Error<*> -> this as Result.Error<R>
-        two is Result.Error<*> -> two as Result.Error<R>
-        three is Result.Error<*> -> three as Result.Error<R>
-        four is Result.Error<*> -> four as Result.Error<R>
+        this is Result.Error<*> -> this.retypeErrorCode()
+        two is Result.Error<*> -> two.retypeErrorCode()
+        three is Result.Error<*> -> three.retypeErrorCode()
+        four is Result.Error<*> -> four.retypeErrorCode()
         else -> Result.Success(
             transform(
                 (this as Result.Success).data,

--- a/kaal-infrastructure/src/main/kotlin/cz/eman/kaal/infrastructure/api/InvalidData.kt
+++ b/kaal-infrastructure/src/main/kotlin/cz/eman/kaal/infrastructure/api/InvalidData.kt
@@ -1,0 +1,11 @@
+package cz.eman.kaal.infrastructure.api
+
+import cz.eman.kaal.domain.result.ErrorResult
+
+/**
+ * Class informing that data was invalid.
+ *
+ * @author eMan a.s.
+ * @since 0.9.0
+ */
+data class InvalidData(val errorResult: ErrorResult) : Exception()

--- a/kaal-infrastructure/src/main/kotlin/cz/eman/kaal/infrastructure/api/retrofit/KaalRetrofitCaller.kt
+++ b/kaal-infrastructure/src/main/kotlin/cz/eman/kaal/infrastructure/api/retrofit/KaalRetrofitCaller.kt
@@ -1,0 +1,84 @@
+package cz.eman.kaal.infrastructure.api.retrofit
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import cz.eman.kaal.domain.result.ErrorCode
+import cz.eman.kaal.domain.result.ErrorResult
+import cz.eman.kaal.domain.result.Result
+import cz.eman.logger.logError
+import retrofit2.Response
+import java.util.Optional
+
+/**
+ * Interface for Kaal retrofit2 calls providing functions which it can handle.
+ *
+ * @author eMan a.s.
+ * @since 0.9.0
+ */
+interface KaalRetrofitCaller {
+
+    /**
+     * Calls a [responseCall] and handles the response using [responseCall]. Uses [map] function to determine if the
+     * call was successful and result data is not null. If it is it will throw and catch [IllegalStateException]
+     * informing that this call should not be used with empty body calls.
+     *
+     * @param responseCall Retrofit2 call to handle
+     * @param errorMessage used to modify error message
+     * @param map function mapping [Dto] object to [T] object
+     * @since 0.9.0
+     */
+    suspend fun <Dto, T> callResult(
+        responseCall: suspend () -> Response<Dto>,
+        errorMessage: () -> String?,
+        map: suspend (Dto) -> T
+    ): Result<T>
+
+    /**
+     * Calls a [responseCall] and handles the response using [responseCall]. Uses [map] function to wrap resulting data
+     * in [Optional]. If the data is null then it uses [Optional.empty] to return empty result.
+     *
+     * @param responseCall Retrofit2 call to handle
+     * @param errorMessage used to modify error message
+     * @param map function mapping [Dto] object to [T] object
+     * @since 0.9.0
+     */
+    @RequiresApi(Build.VERSION_CODES.N)
+    suspend fun <Dto, T> callResultOptional(
+        responseCall: suspend () -> Response<Dto>,
+        errorMessage: () -> String?,
+        map: suspend (Dto) -> T
+    ): Result<Optional<T>>
+
+    /**
+     * Calls a [responseCall] and handles the response using [responseCall]. Can return result with nullable [T] object
+     * when response was successful but no data was returned.
+     *
+     * @param responseCall Retrofit2 call to handle
+     * @param errorMessage used to modify error message
+     * @param map function mapping [Dto] object to [T] object
+     * @see responseCall
+     * @since 0.9.0
+     */
+    suspend fun <Dto, T> callResultNull(
+        responseCall: suspend () -> Response<Dto>,
+        errorMessage: () -> String?,
+        map: suspend (Dto) -> T
+    ): Result<T?>
+
+    /**
+     * Creates [Result.Error] using function parameters. It also logs the error to be visible in the log (uses Timber).
+     *
+     * @param code error code
+     * @param message containing error information
+     * @param throwable containing detail (exception) information
+     * @since 0.9.0
+     */
+    fun <T> errorResult(
+        code: ErrorCode = ErrorCode.UNDEFINED,
+        message: String,
+        throwable: Throwable? = null
+    ): Result<T> {
+        message.logError(message, throwable)
+        return Result.error(error = ErrorResult(code = code, message = message, throwable = throwable))
+    }
+}

--- a/kaal-infrastructure/src/main/kotlin/cz/eman/kaal/infrastructure/api/retrofit/KaalRetrofitCaller.kt
+++ b/kaal-infrastructure/src/main/kotlin/cz/eman/kaal/infrastructure/api/retrofit/KaalRetrofitCaller.kt
@@ -5,26 +5,31 @@ import androidx.annotation.RequiresApi
 import cz.eman.kaal.domain.result.ErrorCode
 import cz.eman.kaal.domain.result.ErrorResult
 import cz.eman.kaal.domain.result.Result
+import cz.eman.kaal.domain.result.map
 import cz.eman.logger.logError
 import retrofit2.Response
 import java.util.Optional
 
 /**
- * Interface for Kaal retrofit2 calls providing functions which it can handle.
+ * Interface for Kaal Retrofit2 calls providing functions which it can handle.
  *
  * @author eMan a.s.
  * @since 0.9.0
  */
+@Suppress("unused")
 interface KaalRetrofitCaller {
 
     /**
-     * Calls a [responseCall] and handles the response using [responseCall]. Uses [map] function to determine if the
-     * call was successful and result data is not null. If it is it will throw and catch [IllegalStateException]
-     * informing that this call should not be used with empty body calls.
+     * Calls a [responseCall] and handles the result by mapping the [Dto] object to [T] on success else it returns
+     * [Result.Error] on any error or exception.
+     *
+     * Note: This function conciser successful response with null body as an error. If the API should return empty body
+     * for example with 204/205/304 codes then use [callResultOptional], [callResultNull].
      *
      * @param responseCall Retrofit2 call to handle
      * @param errorMessage used to modify error message
      * @param map function mapping [Dto] object to [T] object
+     * @return [Result] with [T]
      * @since 0.9.0
      */
     suspend fun <Dto, T> callResult(
@@ -34,12 +39,13 @@ interface KaalRetrofitCaller {
     ): Result<T>
 
     /**
-     * Calls a [responseCall] and handles the response using [responseCall]. Uses [map] function to wrap resulting data
-     * in [Optional]. If the data is null then it uses [Optional.empty] to return empty result.
+     * Calls a [responseCall] and handles the result by mapping the [Dto] object to [Optional]<[T]> on success else it
+     * returns [Result.Error] on any error or exception. Optional allows support for empty body.
      *
      * @param responseCall Retrofit2 call to handle
      * @param errorMessage used to modify error message
      * @param map function mapping [Dto] object to [T] object
+     * @return [Result] with [Optional]<[T]> allowing success with empty body
      * @since 0.9.0
      */
     @RequiresApi(Build.VERSION_CODES.N)
@@ -50,13 +56,29 @@ interface KaalRetrofitCaller {
     ): Result<Optional<T>>
 
     /**
-     * Calls a [responseCall] and handles the response using [responseCall]. Can return result with nullable [T] object
-     * when response was successful but no data was returned.
+     * Calls a [responseCall] and handles the result by mapping the [Dto] object to [Unit] on success else it returns
+     * [Result.Error] on any error or exception. [Unit] allows ignoring the actual result and only check for success.
+     *
+     * @param responseCall Retrofit2 call to handle
+     * @param errorMessage used to modify error message
+     * @param map function mapping [Dto] object to [Unit] object (kept to be used for logging or other functions)
+     * @return [Result] with [Unit]
+     * @since 0.9.0
+     */
+    suspend fun <Dto> callResultUnit(
+        responseCall: suspend () -> Response<Dto>,
+        errorMessage: () -> String?,
+        map: suspend (Dto) -> Unit = { }
+    ): Result<Unit> = callResultNull(responseCall, errorMessage, map).map { }
+
+    /**
+     * Calls a [responseCall] and handles the result by mapping the [Dto] object to nullable [T] on success else it
+     * returns [Result.Error] on any error or exception. Optional allows support for empty body.
      *
      * @param responseCall Retrofit2 call to handle
      * @param errorMessage used to modify error message
      * @param map function mapping [Dto] object to [T] object
-     * @see responseCall
+     * @return [Result] with [T]? (nullable) allowing success with empty body
      * @since 0.9.0
      */
     suspend fun <Dto, T> callResultNull(
@@ -64,6 +86,43 @@ interface KaalRetrofitCaller {
         errorMessage: () -> String?,
         map: suspend (Dto) -> T
     ): Result<T?>
+
+    /**
+     * Calls a [responseCall] and handles the result by mapping the [Dto] object to [Optional]<[T]> on success else it
+     * returns [Result.Error] on any error or exception. Optional allows support for empty body. Result of this function
+     * is a [Pair] of [Result] and [Response] so you can easily access any response metadata you need (like headers,
+     * result code and others provided by Retrofit2).
+     *
+     * @param responseCall Retrofit2 call to handle
+     * @param errorMessage used to modify error message
+     * @param map function mapping [Dto] object to [T] object
+     * @return [Pair] of [Result] with [T] data to [Response] with [Dto] object
+     * @since 0.9.0
+     */
+    @RequiresApi(Build.VERSION_CODES.N)
+    suspend fun <Dto, T> callResultResponseOptional(
+        responseCall: suspend () -> Response<Dto>,
+        errorMessage: () -> String?,
+        map: suspend (Dto) -> T
+    ): Pair<Result<Optional<T>>, Response<Dto>?>
+
+    /**
+     * Calls a [responseCall] and handles the result by mapping the [Dto] object to nullable [T] on success else it
+     * returns [Result.Error] on any error or exception. Optional allows support for empty body. Nullable allows support
+     * for empty body. Result of this function is a [Pair] of [Result] and [Response] so you can easily access any
+     * response metadata you need (like headers, result code and others provided by Retrofit2).
+     *
+     * @param responseCall Retrofit2 call to handle
+     * @param errorMessage used to modify error message
+     * @param map function mapping [Dto] object to [T] object
+     * @return [Pair] of [Result] with [T] data to [Response] with [Dto] object
+     * @since 0.9.0
+     */
+    suspend fun <Dto, T> callResultResponseNull(
+        responseCall: suspend () -> Response<Dto>,
+        errorMessage: () -> String?,
+        map: suspend (Dto) -> T
+    ): Pair<Result<T?>, Response<Dto>?>
 
     /**
      * Creates [Result.Error] using function parameters. It also logs the error to be visible in the log (uses Timber).

--- a/kaal-infrastructure/src/main/kotlin/cz/eman/kaal/infrastructure/api/retrofit/KaalRetrofitCallerImpl.kt
+++ b/kaal-infrastructure/src/main/kotlin/cz/eman/kaal/infrastructure/api/retrofit/KaalRetrofitCallerImpl.kt
@@ -23,13 +23,21 @@ import java.util.Optional
 open class KaalRetrofitCallerImpl : KaalRetrofitCaller {
 
     /**
-     * Calls a [responseCall] and handles the response using [responseCall]. Uses [map] function to determine if the
-     * call was successful and result data is not null. If it is it will throw and catch [IllegalStateException]
-     * informing that this call should not be used with empty body calls.
+     * Calls a [responseCall] and handles the result by mapping the [Dto] object to [T] on success else it returns
+     * [Result.Error] on any error or exception.
+     *
+     * Handles response using [handleResponse] which is then mapped using [Result.map] function to determine if the call
+     * was successful and result body is not null. If it is it will throw and catch [IllegalStateException] informing
+     * that this call should not be used with empty body calls. If any exception occurs it is handled by
+     * [handleCallException].
+     *
+     * Note: This function conciser successful response with null body as an error. If the API should return empty body
+     * for example with 204/205/304 codes then use [callResultOptional], [callResultNull].
      *
      * @param responseCall Retrofit2 call to handle
      * @param errorMessage used to modify error message
      * @param map function mapping [Dto] object to [T] object
+     * @return [Result] with [T]
      * @see responseCall
      * @see handleResponse
      * @see handleCallException
@@ -50,15 +58,17 @@ open class KaalRetrofitCallerImpl : KaalRetrofitCaller {
     }
 
     /**
-     * Calls a [responseCall] and handles the response using [responseCall]. Uses [map] function to wrap resulting data
-     * in [Optional]. If the data is null then it uses [Optional.empty] to return empty result.
+     * Calls a [responseCall] and handles the result by mapping the [Dto] object to [Optional]<[T]> on success else it
+     * returns [Result.Error] on any error or exception. Optional allows support for empty body.
+     *
+     * This function calls [callResultNull] which can return [Result] result with null body. This result is then mapped
+     * to [Optional] using [Result.map].
      *
      * @param responseCall Retrofit2 call to handle
      * @param errorMessage used to modify error message
      * @param map function mapping [Dto] object to [T] object
-     * @see responseCall
-     * @see handleResponse
-     * @see handleCallException
+     * @return [Result] with [Optional]<[T]> allowing success with empty body
+     * @see callResultNull
      * @since 0.9.0
      */
     @RequiresApi(Build.VERSION_CODES.N)
@@ -67,26 +77,26 @@ open class KaalRetrofitCallerImpl : KaalRetrofitCaller {
         errorMessage: () -> String?,
         map: suspend (Dto) -> T
     ): Result<Optional<T>> {
-        return try {
-            handleResponse(responseCall(), map).map { data: T? ->
-                if (data != null) {
-                    Optional.of(data)
-                } else {
-                    Optional.empty()
-                }
+        return callResultNull(responseCall, errorMessage, map).map { data ->
+            if (data != null) {
+                Optional.of(data)
+            } else {
+                Optional.empty()
             }
-        } catch (ex: Exception) {
-            handleCallException(ex, errorMessage())
         }
     }
 
     /**
-     * Calls a [responseCall] and handles the response using [responseCall]. Can return result with nullable [T] object
-     * when response was successful but no data was returned.
+     * Calls a [responseCall] and handles the result by mapping the [Dto] object to nullable [T] on success else it
+     * returns [Result.Error] on any error or exception. Optional allows support for empty body.
+     *
+     * Handles response using [handleResponse] and is returned. If any exception occurs it is handled by
+     * [handleCallException].
      *
      * @param responseCall Retrofit2 call to handle
      * @param errorMessage used to modify error message
      * @param map function mapping [Dto] object to [T] object
+     * @return [Result] with [T]? (nullable) allowing success with empty body
      * @see responseCall
      * @see handleResponse
      * @see handleCallException
@@ -105,12 +115,79 @@ open class KaalRetrofitCallerImpl : KaalRetrofitCaller {
     }
 
     /**
+     * Calls a [responseCall] and handles the result by mapping the [Dto] object to [Optional]<[T]> on success else it
+     * returns [Result.Error] on any error or exception. Optional allows support for empty body. Result of this function
+     * is a [Pair] of [Result] and [Response] so you can easily access any response metadata you need (like headers,
+     * result code and others provided by Retrofit2).
+     *
+     * This function calls [callResultResponseNull] which can return [Result] result with null body. This result is then
+     * mapped to [Optional] using [Result.map].
+     *
+     * @param responseCall Retrofit2 call to handle
+     * @param errorMessage used to modify error message
+     * @param map function mapping [Dto] object to [T] object
+     * @return [Pair] of [Result] with [T] data to [Response]? (nullable) with [Dto] object
+     * @see responseCall
+     * @see handleResponse
+     * @see handleCallException
+     * @since 0.9.0
+     */
+    @RequiresApi(Build.VERSION_CODES.N)
+    override suspend fun <Dto, T> callResultResponseOptional(
+        responseCall: suspend () -> Response<Dto>,
+        errorMessage: () -> String?,
+        map: suspend (Dto) -> T
+    ): Pair<Result<Optional<T>>, Response<Dto>?> {
+        val response = callResultResponseNull(responseCall, errorMessage, map)
+        return response.first.map { data ->
+            if (data != null) {
+                Optional.of(data)
+            } else {
+                Optional.empty()
+            }
+        } to response.second
+    }
+
+    /**
+     * Calls a [responseCall] and handles the result by mapping the [Dto] object to nullable [T] on success else it
+     * returns [Result.Error] on any error or exception. Optional allows support for empty body. Nullable allows support
+     * for empty body. Result of this function is a [Pair] of [Result] and [Response] so you can easily access any
+     * response metadata you need (like headers, result code and others provided by Retrofit2).
+     *
+     * Handles response using [handleResponse], paired up with response and then returned. If any exception occurs it is
+     * handled by [handleCallException] and paired to response (if possible).
+     *
+     * @param responseCall Retrofit2 call to handle
+     * @param errorMessage used to modify error message
+     * @param map function mapping [Dto] object to [T] object
+     * @return [Pair] of [Result] with [T]? (nullable) data to [Response]? (nullable) with [Dto] object
+     * @see responseCall
+     * @see handleResponse
+     * @see handleCallException
+     * @since 0.9.0
+     */
+    override suspend fun <Dto, T> callResultResponseNull(
+        responseCall: suspend () -> Response<Dto>,
+        errorMessage: () -> String?,
+        map: suspend (Dto) -> T
+    ): Pair<Result<T?>, Response<Dto>?> {
+        var response: Response<Dto>? = null
+        return try {
+            response = responseCall()
+            handleResponse(response, map) to response
+        } catch (ex: Exception) {
+            handleCallException<T>(ex, errorMessage()) to response
+        }
+    }
+
+    /**
      * Creates an error from the [response]. Gets error code from the response and parses it to [HttpStatusErrorCode].
      * Creates [Result.error] using [errorResult] containing code and response message.
      *
      * @param response used to create [Result.Error]
      * @return [Result] with type [T] - always creates [Result.Error]
      * @see errorResult
+     * @since 0.9.0
      */
     open fun <Dto, T> createApiErrorResult(response: Response<Dto>): Result<T> {
         val responseCode = response.code()
@@ -131,6 +208,7 @@ open class KaalRetrofitCallerImpl : KaalRetrofitCaller {
      * @param errorMessage used to modify [Result.Error] message
      * @return [Result] with type [T] - always creates [Result.Error]
      * @see errorResult
+     * @since 0.9.0
      */
     private fun <T> handleCallException(ex: Exception, errorMessage: String?): Result<T> {
         val errorCode = when (ex) {
@@ -156,6 +234,7 @@ open class KaalRetrofitCallerImpl : KaalRetrofitCaller {
      * @param map used to map [Dto] object to [T]
      * @return @return [Result] with type [T] or null
      * @see createApiErrorResult
+     * @since 0.9.0
      */
     private suspend fun <Dto, T> handleResponse(response: Response<Dto>, map: suspend (Dto) -> T): Result<T?> {
         return when {

--- a/kaal-infrastructure/src/main/kotlin/cz/eman/kaal/infrastructure/api/retrofit/KaalRetrofitCallerImpl.kt
+++ b/kaal-infrastructure/src/main/kotlin/cz/eman/kaal/infrastructure/api/retrofit/KaalRetrofitCallerImpl.kt
@@ -1,0 +1,179 @@
+package cz.eman.kaal.infrastructure.api.retrofit
+
+import android.os.Build
+import androidx.annotation.RequiresApi
+import cz.eman.kaal.domain.result.ErrorCode
+import cz.eman.kaal.domain.result.HttpStatusErrorCode
+import cz.eman.kaal.domain.result.Result
+import cz.eman.kaal.domain.result.map
+import cz.eman.kaal.infrastructure.api.InvalidData
+import cz.eman.logger.logError
+import retrofit2.Response
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
+import java.util.Optional
+
+/**
+ * Implementation of [KaalRetrofitCaller] handling Retrofit2 calls and their results.
+ *
+ * @author eMan a.s.
+ * @since 0.9.0
+ */
+@Suppress("unused")
+open class KaalRetrofitCallerImpl : KaalRetrofitCaller {
+
+    /**
+     * Calls a [responseCall] and handles the response using [responseCall]. Uses [map] function to determine if the
+     * call was successful and result data is not null. If it is it will throw and catch [IllegalStateException]
+     * informing that this call should not be used with empty body calls.
+     *
+     * @param responseCall Retrofit2 call to handle
+     * @param errorMessage used to modify error message
+     * @param map function mapping [Dto] object to [T] object
+     * @see responseCall
+     * @see handleResponse
+     * @see handleCallException
+     * @since 0.9.0
+     */
+    override suspend fun <Dto, T> callResult(
+        responseCall: suspend () -> Response<Dto>,
+        errorMessage: () -> String?,
+        map: suspend (Dto) -> T
+    ): Result<T> {
+        return try {
+            handleResponse(responseCall(), map).map { data ->
+                data ?: throw IllegalStateException(EMPTY_DATA_EXCEPTION)
+            }
+        } catch (ex: Exception) {
+            handleCallException(ex, errorMessage())
+        }
+    }
+
+    /**
+     * Calls a [responseCall] and handles the response using [responseCall]. Uses [map] function to wrap resulting data
+     * in [Optional]. If the data is null then it uses [Optional.empty] to return empty result.
+     *
+     * @param responseCall Retrofit2 call to handle
+     * @param errorMessage used to modify error message
+     * @param map function mapping [Dto] object to [T] object
+     * @see responseCall
+     * @see handleResponse
+     * @see handleCallException
+     * @since 0.9.0
+     */
+    @RequiresApi(Build.VERSION_CODES.N)
+    override suspend fun <Dto, T> callResultOptional(
+        responseCall: suspend () -> Response<Dto>,
+        errorMessage: () -> String?,
+        map: suspend (Dto) -> T
+    ): Result<Optional<T>> {
+        return try {
+            handleResponse(responseCall(), map).map { data: T? ->
+                if (data != null) {
+                    Optional.of(data)
+                } else {
+                    Optional.empty()
+                }
+            }
+        } catch (ex: Exception) {
+            handleCallException(ex, errorMessage())
+        }
+    }
+
+    /**
+     * Calls a [responseCall] and handles the response using [responseCall]. Can return result with nullable [T] object
+     * when response was successful but no data was returned.
+     *
+     * @param responseCall Retrofit2 call to handle
+     * @param errorMessage used to modify error message
+     * @param map function mapping [Dto] object to [T] object
+     * @see responseCall
+     * @see handleResponse
+     * @see handleCallException
+     * @since 0.9.0
+     */
+    override suspend fun <Dto, T> callResultNull(
+        responseCall: suspend () -> Response<Dto>,
+        errorMessage: () -> String?,
+        map: suspend (Dto) -> T
+    ): Result<T?> {
+        return try {
+            handleResponse(responseCall(), map)
+        } catch (ex: Exception) {
+            handleCallException(ex, errorMessage())
+        }
+    }
+
+    /**
+     * Creates an error from the [response]. Gets error code from the response and parses it to [HttpStatusErrorCode].
+     * Creates [Result.error] using [errorResult] containing code and response message.
+     *
+     * @param response used to create [Result.Error]
+     * @return [Result] with type [T] - always creates [Result.Error]
+     * @see errorResult
+     */
+    open fun <Dto, T> createApiErrorResult(response: Response<Dto>): Result<T> {
+        val responseCode = response.code()
+        val errorMessage = response.message()
+        response.logError("$responseCode $errorMessage")
+
+        return errorResult(
+            code = HttpStatusErrorCode.valueOf(responseCode),
+            message = errorMessage
+        )
+    }
+
+    /**
+     * Handles call exception. Any exception that is handled is used to create [Result.Error]. It makes sure the call
+     * does not crash the app and it receives information about what happened.
+     *
+     * @param ex Exception to handle
+     * @param errorMessage used to modify [Result.Error] message
+     * @return [Result] with type [T] - always creates [Result.Error]
+     * @see errorResult
+     */
+    private fun <T> handleCallException(ex: Exception, errorMessage: String?): Result<T> {
+        val errorCode = when (ex) {
+            is InvalidData -> return Result.error(error = ex.errorResult)
+            is SocketTimeoutException -> HttpStatusErrorCode.SOCKET_TIMEOUT
+            is UnknownHostException -> HttpStatusErrorCode.UNKNOWN_HOST
+            else -> ErrorCode.UNDEFINED
+        }
+
+        return errorResult(
+            code = errorCode,
+            message = errorMessage ?: ex.message ?: ex.toString(),
+            throwable = ex
+        )
+    }
+
+    /**
+     * Handles response and returns proper [Result]. If the response is successful and body is not null it will use
+     * [map] function to map [Dto] object to [T]. If it is null it will create [Result.Success] with null body. If the
+     * response is not successful it will create an [createApiErrorResult].
+     *
+     * @param response to be handled and parsed
+     * @param map used to map [Dto] object to [T]
+     * @return @return [Result] with type [T] or null
+     * @see createApiErrorResult
+     */
+    private suspend fun <Dto, T> handleResponse(response: Response<Dto>, map: suspend (Dto) -> T): Result<T?> {
+        return when {
+            response.isSuccessful -> {
+                val body = response.body()
+                if (body != null) {
+                    Result.success(map(body))
+                } else {
+                    Result.success(null)
+                }
+            }
+            else -> createApiErrorResult(response)
+        }
+    }
+
+    companion object {
+        const val EMPTY_DATA_EXCEPTION = "Body was empty in CallResult. If the API returns empty body use " +
+            "CallResultOptional / CallResultNull"
+        const val EMPTY_DATA_MESSAGE = "Body was empty"
+    }
+}

--- a/kaal-infrastructure/src/main/kotlin/cz/eman/kaal/infrastructure/common/Common.kt
+++ b/kaal-infrastructure/src/main/kotlin/cz/eman/kaal/infrastructure/common/Common.kt
@@ -11,7 +11,9 @@ import retrofit2.Response
 /**
  * @author vsouhrada (vaclav.souhrada@eman.cz)
  * @since 0.4.0
+ * @deprecated in 0.9.0 use KaalRetrofitCaller
  */
+@Deprecated("Use KaalRetrofitCaller")
 suspend fun <Dto, T> callResult(
     responseCall: suspend () -> Response<Dto>,
     errorMessage: () -> String?,
@@ -35,7 +37,9 @@ suspend fun <Dto, T> callResult(
 
 /**
  * @since 0.4.0
+ * @deprecated in 0.9.0 use KaalRetrofitCaller
  */
+@Deprecated("Use KaalRetrofitCaller")
 fun <Dto, T> errorApiResult(response: Response<Dto>): Result<T> {
     response.logError("${response.code()} ${response.message()}")
     return Result.error(
@@ -48,8 +52,10 @@ fun <Dto, T> errorApiResult(response: Response<Dto>): Result<T> {
 
 /**
  * @since 0.4.0
+ * @deprecated in 0.9.0 use KaalRetrofitCaller
  */
+@Deprecated("Use KaalRetrofitCaller")
 fun <T> errorResult(message: String, throwable: Throwable?): Result<T> {
-    message.logError(message)
+    message.logError(message, throwable)
     return Result.error(error = ErrorResult(message = message, throwable = throwable))
 }


### PR DESCRIPTION
### Changelog:
- Result extensions for mapping, chaining, combining and other.
- Retrofit caller which has multiple functions.
  - Support classic calls.
  - Supports option / null calls.
  - Supposts calls with access to raw response.
  - Handles and maps multiple exceptions to error codes.
- Added error codes for 3xx and custom ones for Exceptions. (Maybe rename from HttpErrorCodes?).
- Deprecated old calls using Common.kt (infra).
- No breaking change should be introduced (I think :D).

### Cases which it needs to support:
1) Classic calls. :heavy_check_mark:.
2) Calls with empty body :heavy_check_mark:.
3) Calls with ETag for custom handling :heavy_check_mark:.
4) Calls with invalid data :heavy_check_mark:.