### PR TITLE
Version 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,27 @@
 Change Log
 ==========
 
-## 0.9.0 (TBD)
+## 0.10.0 (TBD)
+
+## 0.9.0 (2021-07-19)
+
+### Added
+- Retrofit API caller which has multiple functions.
+- Support for generic API calls.
+- Error codes for 3xx and custom ones for Exceptions. (Will be changed in later releases.)
+- TabLayoutExtensions. Adds dependency to Google Material (https://maven.google.com/web/index.html?q=material#com.google.android.material:material).
+- ViewPager2 extensions.
 
 ### Change
 - `API Break:` The `KoinComponent` has been removed from `KaalViewModel` and `KaalAndroidViewModel`.
 The Koin dependencies was also removed.
+- Result extensions for mapping, chaining, combining and other.
+- Replaced jCenter repository and publication to jCenter with eMan Nexus repository.
+- All existing authors to eMan a.s.
+
+### Deprecated
+- Deprecated old API calling in Common.kt (infra).
+- Deprecated TextView extensions (there is default Android solution in place).
 
 ## 0.8.0 (2020-10-02)
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Kotlin Android Architecture Library - Kaal - by eMan
 
-[![Latest version](https://img.shields.io/github/v/release/eManPrague/kaal)](https://github.com/eManPrague/kaal/releases/tag/v0.8.0)
+[![Latest version](https://img.shields.io/github/v/release/eManPrague/kaal)](https://github.com/eManPrague/kaal/releases/tag/v0.9.0)
 
 [![Slack channel](https://img.shields.io/badge/Chat-Slack-blue.svg)](https://kotlinlang.slack.com/messages/kaal/)
 
@@ -38,11 +38,11 @@ but you can use it also in data and infrastructure, because you need e.g. instan
 
 ```kotlin
 // Gradle Kotlin DSL
-implementation("cz.eman.kaal:kaal-core:0.8.0")
+implementation("cz.eman.kaal:kaal-core:0.9.0")
 ```
 
 ```groovy
-implementation 'cz.eman.kaal:kaal-core:0.8.0'
+implementation 'cz.eman.kaal:kaal-core:0.9.0'
 ```
 
 TBD
@@ -51,11 +51,11 @@ TBD
 
 ```kotlin
 // Gradle Kotlin DSL
-implementation("cz.eman.kaal:kaal-domain:0.8.0")
+implementation("cz.eman.kaal:kaal-domain:0.9.0")
 ```
 
 ```groovy
-implementation 'cz.eman.kaal:kaal-domain:0.8.0'
+implementation 'cz.eman.kaal:kaal-domain:0.9.0'
 ```
 
 TBD
@@ -64,11 +64,11 @@ TBD
 
 ```kotlin
 // Gradle Kotlin DSL
-implementation("cz.eman.kaal:kaal-presentation:0.8.0")
+implementation("cz.eman.kaal:kaal-presentation:0.9.0")
 ```
 
 ```groovy
-implementation 'cz.eman.kaal:kaal-presentation:0.8.0'
+implementation 'cz.eman.kaal:kaal-presentation:0.9.0'
 ```
 
 TBD
@@ -77,11 +77,11 @@ TBD
 
 ```kotlin
 // Gradle Kotlin DSL
-implementation("cz.eman.kaal:kaal-infrastructure:0.8.0")
+implementation("cz.eman.kaal:kaal-infrastructure:0.9.0")
 ```
 
 ```groovy
-implementation 'cz.eman.kaal:kaal-infrastructure:0.8.0'
+implementation 'cz.eman.kaal:kaal-infrastructure:0.9.0'
 ```
 
 TBD

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,4 +22,4 @@ android.enableJetifier=true
 kotlin.code.style=official
 
 #Kaal version version
-version=0.9.0
+version=0.10.0

--- a/kaal-core/build.gradle.kts
+++ b/kaal-core/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.dokka.gradle.DokkaTask
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     id("com.android.library")
@@ -54,6 +55,12 @@ dependencies {
     // Tests
     testImplementation(Dependencies.Test.junit)
     testImplementation(Dependencies.Test.kotlinTest)
+}
+
+tasks.withType<KotlinCompile> {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
 }
 
 val dokka by tasks.getting(DokkaTask::class) {

--- a/kaal-infrastructure/build.gradle.kts
+++ b/kaal-infrastructure/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.dokka.gradle.DokkaTask
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     id("com.android.library")
@@ -66,6 +67,11 @@ dependencies {
     testImplementation(Dependencies.Test.kotlinTest)
 }
 
+tasks.withType<KotlinCompile> {
+    kotlinOptions {
+        jvmTarget = "1.8"
+    }
+}
 
 val dokka by tasks.getting(DokkaTask::class) {
     moduleName = "kaal-infrastructure"

--- a/kaal-presentation/build.gradle.kts
+++ b/kaal-presentation/build.gradle.kts
@@ -1,4 +1,5 @@
 import org.jetbrains.dokka.gradle.DokkaTask
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 plugins {
     id("com.android.library")
@@ -49,6 +50,12 @@ android {
 
     buildFeatures {
         dataBinding = true
+    }
+}
+
+tasks.withType<KotlinCompile> {
+    kotlinOptions {
+        jvmTarget = "1.8"
     }
 }
 


### PR DESCRIPTION
## Version 0.9.0

### Added
- Retrofit API caller which has multiple functions.
- Support for generic API calls.
- Error codes for 3xx and custom ones for Exceptions. (Will be changed in later releases.)
- TabLayoutExtensions. Adds dependency to Google Material (https://maven.google.com/web/index.html?q=material#com.google.android.material:material).
- ViewPager2 extensions.

### Change
- `API Break:` The `KoinComponent` has been removed from `KaalViewModel` and `KaalAndroidViewModel`.
The Koin dependencies was also removed.
- Result extensions for mapping, chaining, combining and other.
- Replaced jCenter repository and publication to jCenter with eMan Nexus repository.
- All existing authors to eMan a.s.

### Deprecated
- Deprecated old API calling in Common.kt (infra).
- Deprecated TextView extensions (there is default Android solution in place).